### PR TITLE
feat: add extra impl

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -24,7 +24,7 @@ source = "git+https://github.com/dojoengine/dojo?tag=v1.4.2#b5eabcf9dd0a552b6c87
 
 [[package]]
 name = "lyricsflip"
-version = "1.2.2"
+version = "1.0.0"
 dependencies = [
  "dojo",
  "dojo_cairo_test",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 cairo-version = "=2.9.4"
 name = "lyricsflip"
-version = "1.2.2"
+version = "1.0.0"
 edition = "2024_07"
 
 [cairo]

--- a/src/models/leaderboard.cairo
+++ b/src/models/leaderboard.cairo
@@ -1,4 +1,4 @@
-use starknet::{ContractAddress};
+use starknet::{ContractAddress, get_block_timestamp};
 use dojo::world::WorldStorage;
 use dojo::model::ModelStorage;
 
@@ -80,6 +80,27 @@ pub impl LeaderboardImpl of LeaderboardTrait {
         }
 
         config
+    }
+
+    fn update_leaderboard(
+        ref world: WorldStorage,
+        player: ContractAddress,
+        player_total_score: u64, // Player's all-time total score
+        player_total_wins: u64 // Player's all-time total wins
+    ) {
+        let timestamp = get_block_timestamp();
+
+        // Check if player is already in leaderboard
+        let existing_player: TopPlayer = world.read_model(player);
+        let is_already_top_player = existing_player.last_updated > 0;
+
+        if is_already_top_player { // Player is already in top 50, just update their score
+        // TODO Self::update_existing_player(ref world, player, player_total_score,
+        // player_total_wins, timestamp);
+        } else { // Player not in top 50, check if they qualify
+        // TODO Self::try_add_new_player(ref world, player, player_total_score, player_total_wins,
+        // timestamp);
+        }
     }
 }
 

--- a/src/models/leaderboard.cairo
+++ b/src/models/leaderboard.cairo
@@ -2,6 +2,8 @@ use starknet::{ContractAddress};
 use dojo::world::WorldStorage;
 use dojo::model::ModelStorage;
 
+use lyricsflip::constants::{GAME_ID};
+
 #[derive(Copy, Drop, Serde, Debug)]
 #[dojo::model]
 pub struct TopPlayer {
@@ -60,6 +62,24 @@ pub impl LeaderboardImpl of LeaderboardTrait {
             }
         };
         Option::Some(*lowest_scoring_player)
+    }
+
+    fn get_config(ref world: WorldStorage) -> LeaderboardConfig {
+        let mut config: LeaderboardConfig = world.read_model(GAME_ID);
+
+        // Check if config exists (uninitialized configs have both values as 0)
+        if config.current_player_count == 0 && config.min_score_to_qualify == 0 {
+            // initialize with defaults
+            config =
+                LeaderboardConfig {
+                    id: GAME_ID,
+                    min_score_to_qualify: 0, // Will be set when first player added
+                    current_player_count: 0,
+                };
+            world.write_model(@config);
+        }
+
+        config
     }
 }
 

--- a/src/models/player.cairo
+++ b/src/models/player.cairo
@@ -11,6 +11,7 @@ pub struct PlayerStats {
     pub rounds_won: u64,
     pub current_streak: u64,
     pub max_streak: u64,
+    pub total_score: u64,
 }
 
 
@@ -24,12 +25,18 @@ pub impl PlayerImpl of PlayerTrait {
         if player_stats.total_rounds == 0
             && player_stats.rounds_won == 0
             && player_stats.current_streak == 0
-            && player_stats.max_streak == 0 {
+            && player_stats.max_streak == 0
+            && player_stats.total_score == 0 {
             // Initialize with default values
             world
                 .write_model(
                     @PlayerStats {
-                        player, total_rounds: 0, rounds_won: 0, current_streak: 0, max_streak: 0,
+                        player,
+                        total_rounds: 0,
+                        rounds_won: 0,
+                        current_streak: 0,
+                        max_streak: 0,
+                        total_score: 0,
                     },
                 );
         }

--- a/src/models/round.cairo
+++ b/src/models/round.cairo
@@ -257,9 +257,11 @@ pub impl RoundImpl of RoundTrait {
 
         // Update winner's stats
         if !winner.is_zero() {
+            let winner_round_player: RoundPlayer = world.read_model((winner, round_id));
             let mut winner_stats: PlayerStats = world.read_model(winner);
             winner_stats.rounds_won += 1;
             winner_stats.current_streak += 1;
+            winner_stats.total_score += winner_round_player.total_score;
 
             // Update max streak if current streak is higher
             if winner_stats.current_streak > winner_stats.max_streak {
@@ -272,8 +274,10 @@ pub impl RoundImpl of RoundTrait {
             for i in 0..players.len() {
                 let player = *players[i];
                 if player != winner {
+                    let round_player: RoundPlayer = world.read_model((player, round_id));
                     let mut player_stats: PlayerStats = world.read_model(player);
                     player_stats.current_streak = 0;
+                    player_stats.total_score += round_player.total_score;
                     world.write_model(@player_stats);
                 }
             }

--- a/src/tests/test_integration.cairo
+++ b/src/tests/test_integration.cairo
@@ -100,10 +100,12 @@ fn test_full_game_flow_two_players() {
     let player_1_stats: PlayerStats = world.read_model(player_1);
     assert(player_1_stats.rounds_won == 1, 'Player 1 should win');
     assert(player_1_stats.current_streak == 1, 'Player 1 should have streak');
+    assert(player_1_stats.total_score > 0, 'Player 1 total score not set');
 
     let player_2_stats: PlayerStats = world.read_model(player_2);
     assert(player_2_stats.rounds_won == 0, 'Player 2 should not win');
     assert(player_2_stats.current_streak == 0, 'Player 2 should have no streak');
+    assert(player_2_stats.total_score > 0, 'Player 2 total score not set');
 }
 
 #[test]

--- a/src/tests/test_leaderboard.cairo
+++ b/src/tests/test_leaderboard.cairo
@@ -127,3 +127,15 @@ fn test_no_players_in_leaderboard() {
     // Assert that result is None
     assert(result.is_none(), 'Should return None');
 }
+
+
+#[test]
+fn test_get_config() {
+    // Setup world storage
+    let mut world = setup();
+
+    let config: LeaderboardConfig = LeaderboardImpl::get_config(ref world);
+
+    assert(config.min_score_to_qualify == 0, 'Default min score should be 0');
+    assert(config.current_player_count == 0, 'Default count should be 0');
+}


### PR DESCRIPTION
- feat: Extend `PlayerStats` model to track cumulative scores
- feat: impl lazy initialization for `leaderboard` configuration
- feat: impl `update_leaderboard` function

closes #59, #61 & #62