### PR TITLE
Date seed generation

### DIFF
--- a/src/models/daily_challenge.cairo
+++ b/src/models/daily_challenge.cairo
@@ -19,7 +19,18 @@ pub impl DailyChallengeImpl of DailyChallengeTrait {
 
     /// Generate deterministic seed from date
     fn generate_seed_from_date(date: u64) -> u64 {
-        0
+        let day_number = date / 86400;
+    
+        // Primary variation using prime multiplier
+        let base = day_number * 31;
+    
+        // Add weekly pattern using prime multiplier
+        let weekly = (day_number % 7) * 13;
+    
+        // Combine and bound to range [0, 999]
+        let seed = (base + weekly) % 1000;
+    
+        seed
     }
 
     /// Calculate day of week from timestamp (0=Monday, 6=Sunday)

--- a/src/models/daily_challenge.cairo
+++ b/src/models/daily_challenge.cairo
@@ -20,16 +20,16 @@ pub impl DailyChallengeImpl of DailyChallengeTrait {
     /// Generate deterministic seed from date
     fn generate_seed_from_date(date: u64) -> u64 {
         let day_number = date / 86400;
-    
+
         // Primary variation using prime multiplier
         let base = day_number * 31;
-    
+
         // Add weekly pattern using prime multiplier
         let weekly = (day_number % 7) * 13;
-    
+
         // Combine and bound to range [0, 999]
         let seed = (base + weekly) % 1000;
-    
+
         seed
     }
 

--- a/src/models/daily_challenge.cairo
+++ b/src/models/daily_challenge.cairo
@@ -24,7 +24,9 @@ pub impl DailyChallengeImpl of DailyChallengeTrait {
 
     /// Calculate day of week from timestamp (0=Monday, 6=Sunday)
     fn get_day_of_week(date: u64) -> u64 {
-        0
+        let days_since_epoch = date / 86400;
+        let day_of_week = (days_since_epoch + 3) % 7;
+        day_of_week
     }
 
     /// Validate date is appropriate for challenge generation

--- a/src/tests/test_daily_challenge.cairo
+++ b/src/tests/test_daily_challenge.cairo
@@ -33,3 +33,37 @@ fn test_is_valid_challenge_date() {
         'Expected false: before launch',
     );
 }
+
+
+#[test]
+fn test_get_day_of_week() {
+    let day = 86400;
+
+    // Jan 1, 2025 (Wednesday)
+    let jan_1 = 1735689600;
+    assert(DailyChallengeTrait::get_day_of_week(jan_1) == 2, 'Expected Wednesday (2)');
+
+    // Jan 2, 2025 (Thursday)
+    let jan_2 = jan_1 + day;
+    assert(DailyChallengeTrait::get_day_of_week(jan_2) == 3, 'Expected Thursday (3)');
+
+    // Jan 3, 2025 (Friday)
+    let jan_3 = jan_2 + day;
+    assert(DailyChallengeTrait::get_day_of_week(jan_3) == 4, 'Expected Friday (4)');
+
+    // Jan 4, 2025 (Saturday)
+    let jan_4 = jan_3 + day;
+    assert(DailyChallengeTrait::get_day_of_week(jan_4) == 5, 'Expected Saturday (5)');
+
+    // Jan 5, 2025 (Sunday)
+    let jan_5 = jan_4 + day;
+    assert(DailyChallengeTrait::get_day_of_week(jan_5) == 6, 'Expected Sunday (6)');
+
+    // Jan 6, 2025 (Monday)
+    let jan_6 = jan_5 + day;
+    assert(DailyChallengeTrait::get_day_of_week(jan_6) == 0, 'Expected Monday (0)');
+
+    // Jan 7, 2025 (Tuesday)
+    let jan_7 = jan_6 + day;
+    assert(DailyChallengeTrait::get_day_of_week(jan_7) == 1, 'Expected Tuesday (1)');
+}

--- a/src/tests/test_daily_challenge.cairo
+++ b/src/tests/test_daily_challenge.cairo
@@ -76,12 +76,27 @@ fn test_generate_seed_from_date() {
 
     // Jan 2, 2025
     let jan_2 = jan_1 + 86400;
-    assert(DailyChallengeTrait::generate_seed_from_date(jan_2) != DailyChallengeTrait::generate_seed_from_date(jan_1), 'same seed next day');
+    assert(
+        DailyChallengeTrait::generate_seed_from_date(
+            jan_2,
+        ) != DailyChallengeTrait::generate_seed_from_date(jan_1),
+        'same seed next day',
+    );
 
     // Same date = same seed
-    assert(DailyChallengeTrait::generate_seed_from_date(jan_1) == DailyChallengeTrait::generate_seed_from_date(jan_1), 'seed not stable');
+    assert(
+        DailyChallengeTrait::generate_seed_from_date(
+            jan_1,
+        ) == DailyChallengeTrait::generate_seed_from_date(jan_1),
+        'seed not stable',
+    );
 
     // Jan 8, 2025 = same weekday as Jan 1, test variation
     let jan_8 = jan_1 + 86400 * 7;
-    assert(DailyChallengeTrait::generate_seed_from_date(jan_8) != DailyChallengeTrait::generate_seed_from_date(jan_1), 'seed repeat weekly');
+    assert(
+        DailyChallengeTrait::generate_seed_from_date(
+            jan_8,
+        ) != DailyChallengeTrait::generate_seed_from_date(jan_1),
+        'seed repeat weekly',
+    );
 }

--- a/src/tests/test_daily_challenge.cairo
+++ b/src/tests/test_daily_challenge.cairo
@@ -67,3 +67,21 @@ fn test_get_day_of_week() {
     let jan_7 = jan_6 + day;
     assert(DailyChallengeTrait::get_day_of_week(jan_7) == 1, 'Expected Tuesday (1)');
 }
+
+#[test]
+fn test_generate_seed_from_date() {
+    // Jan 1, 2025
+    let jan_1 = 1735689600;
+    assert(DailyChallengeTrait::generate_seed_from_date(jan_1) <= 999, 'out of range');
+
+    // Jan 2, 2025
+    let jan_2 = jan_1 + 86400;
+    assert(DailyChallengeTrait::generate_seed_from_date(jan_2) != DailyChallengeTrait::generate_seed_from_date(jan_1), 'same seed next day');
+
+    // Same date = same seed
+    assert(DailyChallengeTrait::generate_seed_from_date(jan_1) == DailyChallengeTrait::generate_seed_from_date(jan_1), 'seed not stable');
+
+    // Jan 8, 2025 = same weekday as Jan 1, test variation
+    let jan_8 = jan_1 + 86400 * 7;
+    assert(DailyChallengeTrait::generate_seed_from_date(jan_8) != DailyChallengeTrait::generate_seed_from_date(jan_1), 'seed repeat weekly');
+}


### PR DESCRIPTION
## 🎲 Implement Deterministic Seed Generator for Daily Challenges

### Closes #91
This PR adds the `generate_seed_from_date(date: u64) -> u64` function that produces a consistent, pseudo-random seed based on a given UTC date. This seed will be used to generate globally synchronized daily challenges, ensuring fairness and reproducibility across all users.

---

### 🧠 Design Overview

The seed generation is:
- **Deterministic**: Same input date always produces the same output seed.
- **Bounded**: Output is constrained to the range `0–999`.
- **Varied**: Uses prime number multipliers to ensure non-linear, non-repeating sequences across dates.
- **Timezone-independent**: Operates purely on UTC timestamps.